### PR TITLE
Rewrite core functionality in carp

### DIFF
--- a/docs/File.html
+++ b/docs/File.html
@@ -386,7 +386,10 @@ file.</p>
                     (read f len)
                 </pre>
                 <p class="doc">
-                    
+                    <p>reads a string of length <code>len</code> from a file.</p>
+<p>Returns a result containing the string on success and an error if the file is
+not readable.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -405,7 +408,10 @@ file.</p>
                     (read-all f)
                 </pre>
                 <p class="doc">
-                    
+                    <p>reads the entire file content of a file.</p>
+<p>Returns a result containing the string on success and an error if the file is
+not readable.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -469,126 +475,6 @@ file.</p>
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#set-file">
-                    <h3 id="set-file">
-                        set-file
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [File, (Ptr FILE)] File)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>sets the <code>file</code> property of a <code>File</code>.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#set-file!">
-                    <h3 id="set-file!">
-                        set-file!
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [(Ref File), (Ptr FILE)] ())
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>sets the <code>file</code> property of a <code>File</code> in place.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#set-mode">
-                    <h3 id="set-mode">
-                        set-mode
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [File, String] File)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>sets the <code>mode</code> property of a <code>File</code>.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#set-mode!">
-                    <h3 id="set-mode!">
-                        set-mode!
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [(Ref File), String] ())
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>sets the <code>mode</code> property of a <code>File</code> in place.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#set-name">
-                    <h3 id="set-name">
-                        set-name
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [File, String] File)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>sets the <code>name</code> property of a <code>File</code>.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#set-name!">
-                    <h3 id="set-name!">
-                        set-name!
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [(Ref File), String] ())
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>sets the <code>name</code> property of a <code>File</code> in place.</p>
-
-                </p>
-            </div>
-            <div class="binder">
                 <a class="anchor" href="#str">
                     <h3 id="str">
                         str
@@ -605,66 +491,6 @@ file.</p>
                 </span>
                 <p class="doc">
                     <p>converts a <code>File</code> to a string.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#update-file">
-                    <h3 id="update-file">
-                        update-file
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [File, (Ref (λ [(Ptr FILE)] (Ptr FILE)))] File)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>updates the <code>file</code> property of a <code>File</code> using a function <code>f</code>.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#update-mode">
-                    <h3 id="update-mode">
-                        update-mode
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [File, (Ref (λ [String] String))] File)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>updates the <code>mode</code> property of a <code>File</code> using a function <code>f</code>.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#update-name">
-                    <h3 id="update-name">
-                        update-name
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [File, (Ref (λ [String] String))] File)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>updates the <code>name</code> property of a <code>File</code> using a function <code>f</code>.</p>
 
                 </p>
             </div>
@@ -771,9 +597,9 @@ nonexistant directory.</p>
                     (write f string)
                 </pre>
                 <p class="doc">
-                    <p>reads the entire file content of a file.</p>
-<p>Returns a result containing the string on success and an error if the file is
-not readable.</p>
+                    <p>writes a string <code>string</code> to a file.</p>
+<p>Returns a result containing nothing on success and an error if the file is not
+writable.</p>
 
                 </p>
             </div>

--- a/docs/File.html
+++ b/docs/File.html
@@ -127,8 +127,6 @@ mode.</p>
 <p>Returns a result containing either the contents of that directory or an error
 if the directory couldn’t be opened due to permission errors or if the user
 tried to open a nonexistant directory.</p>
-<p>It will currently fail when being passed a lambda which accesses any closure
-variables due to a limitation of the Carp compiler.</p>
 
                 </p>
             </div>
@@ -152,8 +150,6 @@ variables due to a limitation of the Carp compiler.</p>
 <p>Returns a result containing either the directory contents or an error if the
 directory couldn’t be opened due to permission errors or if the user tried to
 open a nonexistant directory.</p>
-<p>It will currently fail when being passed a lambda which accesses any closure
-variables due to a limitation of the Carp compiler.</p>
 
                 </p>
             </div>
@@ -215,48 +211,55 @@ variables due to a limitation of the Carp compiler.</p>
                 </span>
                 <p class="doc">
                     <p>is the default options used by <a href="#walk"><code>walk</code></a>.</p>
-<p>Initially set to recursive, not following links, and not matching directories or
-dotfiles.</p>
+<p>Initially set to recursive, not following links, and not matching directories
+or dotfiles.</p>
 
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#file">
-                    <h3 id="file">
-                        file
+                <a class="anchor" href="#map">
+                    <h3 id="map">
+                        map
                     </h3>
                 </a>
                 <div class="description">
-                    instantiate
+                    defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref File)] (Ref (Ptr FILE)))
+                    (λ [&amp;String, (Ref (λ [&amp;String] a))] (Result (Array a) String))
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (map s callback)
+                </pre>
                 <p class="doc">
-                    <p>gets the <code>file</code> property of a <code>File</code>.</p>
+                    <p>walks a directory with the default walk mode (see also
+<a href="#default-walk"><code>default-walk</code></a>).</p>
+<p>Returns a result containing either the results of the walker function as an
+array or an error if the directory couldn’t be opened due to permission errors
+or if the user tried to open a nonexistant directory.</p>
 
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#init">
-                    <h3 id="init">
-                        init
+                <a class="anchor" href="#map-with">
+                    <h3 id="map-with">
+                        map-with
                     </h3>
                 </a>
                 <div class="description">
-                    instantiate
+                    defn
                 </div>
                 <p class="sig">
-                    (λ [String, String, (Ptr FILE)] File)
+                    (λ [&amp;String, (Ref (λ [&amp;String] a)), (Ref WalkOptions)] (Result (Array a) String))
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (map-with s callback options)
+                </pre>
                 <p class="doc">
-                    <p>creates a <code>File</code>.</p>
+                    <p>walks a directory with a custom <a href="#walk-mode">walk mode</a>.</p>
+<p>Returns a result containing either the results of the walker function as an
+array or an error if the directory couldn’t be opened due to permission errors
+or if the user tried to open a nonexistant directory.</p>
 
                 </p>
             </div>
@@ -675,7 +678,7 @@ file.</p>
                     defn
                 </div>
                 <p class="sig">
-                    (λ [&amp;String, (Ref (λ [String] ()))] (Result Int String))
+                    (λ [&amp;String, (Ref (λ [&amp;String] ()))] (Result Int String))
                 </p>
                 <pre class="args">
                     (walk s callback)
@@ -686,8 +689,6 @@ file.</p>
 <p>Returns a result containing either nothing, or an error if the directory
 couldn’t be opened due to permission errors or if the user tried to open a
 nonexistant directory.</p>
-<p>It will currently fail when being passed a lambda which accesses any closure
-variables due to a limitation of the Carp compiler.</p>
 
                 </p>
             </div>
@@ -721,7 +722,7 @@ variables due to a limitation of the Carp compiler.</p>
                     defn
                 </div>
                 <p class="sig">
-                    (λ [&amp;String, (Ref (λ [String] ())), (Ref WalkOptions)] (Result Int String))
+                    (λ [&amp;String, (Ref (λ [&amp;String] ())), (Ref WalkOptions)] (Result Int String))
                 </p>
                 <pre class="args">
                     (walk-with s callback options)
@@ -731,8 +732,6 @@ variables due to a limitation of the Carp compiler.</p>
 <p>Returns a result containing either nothing, or an error if the directory
 couldn’t be opened due to permission errors or if the user tried to open a
 nonexistant directory.</p>
-<p>It will currently fail when being passed a lambda which accesses any closure
-variables due to a limitation of the Carp compiler.</p>
 
                 </p>
             </div>

--- a/file.carp
+++ b/file.carp
@@ -87,11 +87,17 @@ You can also ask about the modes of the file, using the functions `readable?`,
   (hidden is-dir)
   (register is-dir (Fn [Int] Bool) "S_ISDIR")
 
-  (private init)
   (hidden init)
-
-  (private file)
   (hidden file)
+  (hidden set-mode)
+  (hidden set-file)
+  (hidden set-name)
+  (hidden set-mode!)
+  (hidden set-file!)
+  (hidden set-name!)
+  (hidden update-mode)
+  (hidden update-file)
+  (hidden update-name)
 
   ; the actual low-level implementation of File.walk
   (defn walk-recur [dname op spec]
@@ -251,7 +257,7 @@ writable.")
         (Result.Success 0))
       (Result.Error (fmt "The file “%s” is not writable" (name f)))))
 
-  (doc write "reads a string of length `len` from a file.
+  (doc read "reads a string of length `len` from a file.
 
 Returns a result containing the string on success and an error if the file is
 not readable.")
@@ -262,7 +268,7 @@ not readable.")
         (Result.Success s))
       (Result.Error (fmt "The file “%s” is not readable" (name f)))))
 
-  (doc write "reads the entire file content of a file.
+  (doc read-all "reads the entire file content of a file.
 
 Returns a result containing the string on success and an error if the file is
 not readable.")

--- a/file.carp
+++ b/file.carp
@@ -1,5 +1,12 @@
 (relative-include "file_helper.h")
 
+(defmodule Dir
+  (register open (Fn [(Ptr Char)] (Ptr DIR)) "opendir")
+  (register close (Fn [(Ptr DIR)] ()) "closedir")
+  (register read (Fn [(Ptr DIR)] (Ptr DirEntry)) "readdir")
+  (register d-name (Fn [(Ptr DirEntry)] (Ptr Char)) "Dir_d_name")
+)
+
 (deftype File [name String, mode String, file (Ptr FILE)])
 (deftype WalkOptions [
   recursive? Bool,
@@ -8,18 +15,12 @@
   match-dirs? Bool,
 ])
 
-(defmodule WalkOptions
-  (register RECURSIVE Int "WS_RECURSIVE")
-  (register FOLLOWLINK Int "WS_FOLLOWLINK")
-  (register DOTFILES Int "WS_DOTFILES")
-  (register MATCHDIRS Int "WS_MATCHDIRS")
-
-  (defn to-int [o]
-    (Int.bit-or (if @(recursive? o) RECURSIVE 0)
-      (Int.bit-or (if @(follow-links? o) FOLLOWLINK 0)
-        (Int.bit-or (if @(dotfiles? o) DOTFILES 0)
-                    (if @(match-dirs? o) MATCHDIRS 0)))))
-)
+(defmacro until-expr [bs expr body]
+  (list 'while true
+    (list 'let bs
+      (list 'if expr
+        '(break)
+        (list 'do body)))))
 
 (doc File "A simple file abstraction for Carp.
 
@@ -75,21 +76,49 @@ You can also ask about the modes of the file, using the functions `readable?`,
 `writable?`, or `binary-mode?`.")
 
 (defmodule File
-  (hidden OK)
-  (register OK Int "WALK_OK")
-  (hidden NAME-TOO-LONG)
-  (register NAME-TOO-LONG Int "WALK_NAMETOOLONG")
-  (hidden CANT-OPEN)
-  (register CANT-OPEN Int "WALK_CANTOPEN")
-  (hidden CANT-STAT)
-  (register CANT-STAT Int "WALK_CANTSTAT")
-  (hidden walk-internal)
-  (register walk-internal (Fn [&String (Fn [String] ()) Int] Int) "walk_dir")
+  (register stat (Fn [(Ref String)] Int) "File_stat")
+
+  (register is-link (Fn [Int] Bool) "S_ISLNK")
+  (register is-dir (Fn [Int] Bool) "S_ISDIR")
+
+  ; the actual low-level implementation of File.walk
+  (defn walk-recur [dname op spec]
+    (let [dir (Dir.open (cstr dname))
+          res (Result.Success 0)]
+      (if (null? dir)
+        (Result.Error (fmt "Can’t open '%s'" dname))
+        (do
+          (until-expr
+            [dent (Dir.read dir)]
+            (null? dent)
+            (let [name &(from-cstr (Dir.d-name dent))]
+              (cond
+                (and (not @(WalkOptions.dotfiles? spec)) (starts-with? name ".")) ()
+                (or (= name ".") (= name "..")) ()
+                (let-do [f (fmt "%s/%s" dname name)
+                         lres (stat &f)]
+                  (cond
+                    (= -1 lres)
+                      (do
+                        (set! res (Result.Error (fmt "Can’t stat '%s'" &f)))
+                        (break))
+                    (and (is-link lres) (not @(WalkOptions.follow-links? spec))) ()
+                    (is-dir lres)
+                      (do
+                        (when @(WalkOptions.recursive? spec)
+                          (walk-recur &f op spec))
+                        (when @(WalkOptions.match-dirs? spec)
+                          (~op &f)))
+                    (~op &f))))))
+          (Dir.close dir)
+          res))))
+  (hidden walk-recur)
+  (private walk-recur)
 
   (doc default-walk "is the default options used by [`walk`](#walk).
 
-Initially set to recursive, not following links, and not matching directories or
-dotfiles.")
+Initially set to recursive, not following links, and not matching directories
+or dotfiles.")
   (def default-walk (WalkOptions.init true false false false))
 
   (doc walk-mode "constructs a mode for [`walk-with`](#walk-with).")
@@ -105,12 +134,7 @@ nonexistant directory.
 It will currently fail when being passed a lambda which accesses any closure
 variables due to a limitation of the Carp compiler.")
   (defn walk-with [s callback options]
-    (case (walk-internal s @callback (WalkOptions.to-int options))
-      OK (Result.Success 0)
-      NAME-TOO-LONG (Result.Error (fmt "Filename '%s' too long" s))
-      CANT-OPEN (Result.Error (fmt "Can’t open '%s'" s))
-      CANT-STAT (Result.Error (fmt "Can’t stat '%s'" s))
-      (Result.Error @"Unknown file error")))
+    (walk-recur s callback options))
 
   (doc walk "walks a directory with the default walk mode (see also
 [`default-walk`](#default-walk)).
@@ -140,8 +164,8 @@ variables due to a limitation of the Carp compiler.")
     (do
       (set! contents-res [])
       (Result.map
-        (walk-with s &(fn [f] (Array.push-back! &contents-res f)) options)
-        (fn [_] @&contents-res))))
+        (walk-with s &(fn [f] (Array.push-back! &contents-res @f)) options)
+        &(fn [_] @&contents-res))))
 
   (doc contents "walks a directory with the default walk mode (see also
 [`default-walk`](#default-walk)).

--- a/file.carp
+++ b/file.carp
@@ -76,10 +76,22 @@ You can also ask about the modes of the file, using the functions `readable?`,
 `writable?`, or `binary-mode?`.")
 
 (defmodule File
+  (private stat)
+  (hidden stat)
   (register stat (Fn [(Ref String)] Int) "File_stat")
 
+  (private is-link)
+  (hidden is-link)
   (register is-link (Fn [Int] Bool) "S_ISLNK")
+  (private is-dir)
+  (hidden is-dir)
   (register is-dir (Fn [Int] Bool) "S_ISDIR")
+
+  (private init)
+  (hidden init)
+
+  (private file)
+  (hidden file)
 
   ; the actual low-level implementation of File.walk
   (defn walk-recur [dname op spec]
@@ -129,10 +141,7 @@ or dotfiles.")
 
 Returns a result containing either nothing, or an error if the directory
 couldn’t be opened due to permission errors or if the user tried to open a
-nonexistant directory.
-
-It will currently fail when being passed a lambda which accesses any closure
-variables due to a limitation of the Carp compiler.")
+nonexistant directory.")
   (defn walk-with [s callback options]
     (walk-recur s callback options))
 
@@ -141,41 +150,45 @@ variables due to a limitation of the Carp compiler.")
 
 Returns a result containing either nothing, or an error if the directory
 couldn’t be opened due to permission errors or if the user tried to open a
-nonexistant directory.
-
-It will currently fail when being passed a lambda which accesses any closure
-variables due to a limitation of the Carp compiler.")
+nonexistant directory.")
   (defn walk [s callback]
     (walk-with s callback &default-walk))
 
-  (hidden contents-res)
-  (private contents-res)
-  (def contents-res (the (Array String) []))
+  (doc map-with "walks a directory with a custom [walk mode](#walk-mode).
+
+Returns a result containing either the results of the walker function as an
+array or an error if the directory couldn’t be opened due to permission errors
+or if the user tried to open a nonexistant directory.")
+  (defn map-with [s callback options]
+    (let [res []
+          res-ref &res]
+      (Result.map
+        (walk-with s &(fn [e] (Array.push-back! res-ref (~callback e))) options)
+        &(fn [_] @res-ref))))
+
+  (doc map "walks a directory with the default walk mode (see also
+[`default-walk`](#default-walk)).
+
+Returns a result containing either the results of the walker function as an
+array or an error if the directory couldn’t be opened due to permission errors
+or if the user tried to open a nonexistant directory.")
+  (defn map [s callback]
+    (map-with s callback &default-walk))
 
   (doc contents-with "walks a directory with a custom [walk mode](#walk-mode).
 
 Returns a result containing either the directory contents or an error if the
 directory couldn’t be opened due to permission errors or if the user tried to
-open a nonexistant directory.
-
-It will currently fail when being passed a lambda which accesses any closure
-variables due to a limitation of the Carp compiler.")
+open a nonexistant directory.")
   (defn contents-with [s options]
-    (do
-      (set! contents-res [])
-      (Result.map
-        (walk-with s &(fn [f] (Array.push-back! &contents-res @f)) options)
-        &(fn [_] @&contents-res))))
+    (map-with s &copy options))
 
   (doc contents "walks a directory with the default walk mode (see also
 [`default-walk`](#default-walk)).
 
 Returns a result containing either the contents of that directory or an error
 if the directory couldn’t be opened due to permission errors or if the user
-tried to open a nonexistant directory.
-
-It will currently fail when being passed a lambda which accesses any closure
-variables due to a limitation of the Carp compiler.")
+tried to open a nonexistant directory.")
   (defn contents [s]
     (contents-with s &default-walk))
 

--- a/file_helper.h
+++ b/file_helper.h
@@ -5,75 +5,20 @@
 */
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <dirent.h>
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
-#include <err.h>
 
-enum {
-  WALK_OK = 0,
-  WALK_NAMETOOLONG,
-  WALK_CANTOPEN,
-  WALK_CANTSTAT,
-  WALK_BADIO
-};
- 
-#define WS_NONE    0
-#define WS_RECURSIVE  (1 << 0)
-#define WS_FOLLOWLINK  (1 << 1)  /* follow symlinks */
-#define WS_DOTFILES  (1 << 2)  /* per unix convention, .file is hidden */
-#define WS_MATCHDIRS  (1 << 3)  /* if pattern is used on dir names too */
+typedef struct dirent DirEntry;
 
-int walk_recur(String dname, void (*operation)(String), int spec) {
-  struct dirent *dent;
-  DIR *dir;
-  struct stat st;
-  char fn[FILENAME_MAX];
-  int res = WALK_OK;
-  int len = strlen(dname);
-
-  if (len >= FILENAME_MAX - 1) return WALK_NAMETOOLONG;
-
-  strcpy(fn, dname);
-  fn[len++] = '/';
- 
-  if (!(dir = opendir(dname))) return WALK_CANTOPEN;
- 
-  errno = 0;
-  while ((dent = readdir(dir))) {
-    if (!(spec & WS_DOTFILES) && dent->d_name[0] == '.')
-      continue;
-    if (!strcmp(dent->d_name, ".") || !strcmp(dent->d_name, ".."))
-      continue;
- 
-    strncpy(fn + len, dent->d_name, FILENAME_MAX - len);
-    if (lstat(fn, &st) == -1) {
-      res = WALK_CANTSTAT;
-      continue;
-    }
- 
-    /* don't follow symlink unless told so */
-    if (S_ISLNK(st.st_mode) && !(spec & WS_FOLLOWLINK)) continue;
- 
-    /* will be false for symlinked dirs */
-    if (S_ISDIR(st.st_mode)) {
-      /* recursively follow dirs */
-      if ((spec & WS_RECURSIVE)) walk_recur(fn, operation, spec);
- 
-      if (!(spec & WS_MATCHDIRS)) continue;
-    }
-
-    char* for_carp = malloc(FILENAME_MAX);
-    strcpy(for_carp, fn);
-    (*operation)(for_carp);
-  }
- 
-  if (dir) closedir(dir);
-  return res ? res : errno ? WALK_BADIO : WALK_OK;
+char* Dir_d_name(struct dirent* dent) {
+  return dent->d_name;
 }
 
-int walk_dir(String* dname, void (*operation)(String), int spec) {
-  return walk_recur(*dname, operation, spec);
+int File_stat(char** f) {
+  struct stat st;
+
+  if (lstat(*f, &st) == -1) {
+    return -1;
+  }
+
+  return st.st_mode;
 }

--- a/test/file.carp
+++ b/test/file.carp
@@ -76,16 +76,14 @@
                   "walk-with works on directory"
     )
     (assert-equal test
+                  &[@"./test/nested/fixture" @"./test/file.carp"]
+                  &(Result.from-success (File.map "test" &(fn [s] (fmt "./%s" s))) [])
+                  "map works on directory"
+    )
+    (assert-equal test
                   &[@"test/nested/fixture" @"test/file.carp"]
                   &(Result.from-success (File.contents "test") [])
                   "contents works on directory"
-    )
-    (assert-equal test
-                  &[@"test/nested/fixture" @"test/nested" @"test/file.carp"]
-                  &(Result.from-success
-                    (File.contents-with "test" &(WalkOptions.init true false false true))
-                    [])
-                  "contents-with works on directory"
     )
     (let-do [f (unsafe-from-success (File.open "example"))]
       (File.remove &f)


### PR DESCRIPTION
This PR fixes #4 by rewriting the failing C code in Carp. This is a pretty big change, and it relies on carp-lang/carp#634 and carp-lang/carp#635, so I’ll sit on it for a while before merging it.

Cheers