### PR TITLE
reader: add a reader interface

### DIFF
--- a/file.carp
+++ b/file.carp
@@ -272,7 +272,7 @@ writable.")
     "```"
     "(match (File.open-with \"test-file.txt\" \"r\")"
     "  (Result.Success f) (the (Result (Array Byte) String) (File.read &f 3))"
-    "  (Result.Error x) (the (Result (Array Byte) String) (Result.Error x))))"
+    "  (Result.Error x) (Result.Error x))))"
     "```")
   (defn read [f len]
     (if (readable? f)

--- a/file.carp
+++ b/file.carp
@@ -1,4 +1,5 @@
 (relative-include "file_helper.h")
+(load "src/reader.carp")
 
 (defmodule Dir
   (register open (Fn [(Ptr CChar)] (Ptr DIR)) "opendir")
@@ -257,17 +258,6 @@ writable.")
         (Result.Success 0))
       (Result.Error (fmt "The file “%s” is not writable" (name f)))))
 
-  (doc read "reads a string of length `len` from a file.
-
-Returns a result containing the string on success and an error if the file is
-not readable.")
-  (defn read [f len]
-    (if (readable? f)
-      (let-do [s (String.allocate len (Char.from-int 0))]
-        (ignore (IO.Raw.fread &s 1 len @(file f)))
-        (Result.Success s))
-      (Result.Error (fmt "The file “%s” is not readable" (name f)))))
-
   (doc read-all "reads the entire file content of a file.
 
 Returns a result containing the string on success and an error if the file is
@@ -283,3 +273,6 @@ not readable.")
   (defn rewind [f]
     (IO.Raw.rewind @(file f)))
 )
+
+(load "src/byte-reader.carp")
+(load "src/string-reader.carp")

--- a/file.carp
+++ b/file.carp
@@ -258,6 +258,27 @@ writable.")
         (Result.Success 0))
       (Result.Error (fmt "The file “%s” is not writable" (name f)))))
 
+  (doc read 
+    "Reads len values from a file."
+    ""
+    ("This function is generic in its return argument. You can " false)
+    ("provide a custom reader implementation by implementing the " false)
+    "read-from-file interface."
+    ""
+    ("The surrounding context typically determine's the return type." false)
+    ("if no implementation of read-from-file exists for the type, you'll " false)
+    "need to provide one. You can also use `the` to specify the return type."
+    "For example (to read the first 3 bytes of the file):"
+    "```"
+    "(match (File.open-with \"test-file.txt\" \"r\")"
+    "  (Result.Success f) (the (Result (Array Byte) String) (File.read &f 3))"
+    "  (Result.Error x) (the (Result (Array Byte) String) (Result.Error x))))"
+    "```")
+  (defn read [f len]
+    (if (readable? f)
+        (read-from-file f len)
+        (Result.Error (fmt "The file “%s” is not readable" (name f)))))
+
   (doc read-all "reads the entire file content of a file.
 
 Returns a result containing the string on success and an error if the file is

--- a/src/byte-reader.carp
+++ b/src/byte-reader.carp
@@ -16,5 +16,13 @@
           (++ i))
         (Result.Success bytes)))
     (implements read-from-file read-bytes)
+
+    (doc read 
+      "Reads an array of bytes of length n from a file."
+      ("This is a convenient wrapper that fixes the return" false)
+      "type of File.read to (Array Byte)")
+    (sig read (Fn [&File Int] (Result (Array Byte) String)))
+    (defn read [file n]
+      (File.read file n))
   )
 )

--- a/src/byte-reader.carp
+++ b/src/byte-reader.carp
@@ -1,0 +1,21 @@
+;;;; Byte reader.
+
+(defmodule File
+  (defmodule ByteReader
+    (doc read-byte "Read a single byte from a file.")
+    (defn read-byte [file]
+      (to-byte (Char.from-int (IO.Raw.fgetc file))))
+
+    (doc read "Read n bytes from a file.")
+    (defn read [f n]
+      (if (readable? f)
+          (let-do [bytes (Array.allocate n)
+                   i 0]
+            (while-do (< i n)
+              (Array.aset-uninitialized! &bytes i (read-byte @(file f)))
+              (++ i))
+            (Result.Success bytes))
+          (Result.Error (fmt "The file %s is not readable" (name f)))))
+    (implements read read)
+  )
+)

--- a/src/byte-reader.carp
+++ b/src/byte-reader.carp
@@ -2,20 +2,19 @@
 
 (defmodule File
   (defmodule ByteReader
+    ;; TODO: Use the safer IO.fgetc once in HEAD
     (doc read-byte "Read a single byte from a file.")
     (defn read-byte [file]
       (to-byte (Char.from-int (IO.Raw.fgetc file))))
 
-    (doc read "Read n bytes from a file.")
-    (defn read [f n]
-      (if (readable? f)
-          (let-do [bytes (Array.allocate n)
-                   i 0]
-            (while-do (< i n)
-              (Array.aset-uninitialized! &bytes i (read-byte @(file f)))
-              (++ i))
-            (Result.Success bytes))
-          (Result.Error (fmt "The file %s is not readable" (name f)))))
-    (implements read read)
+    (doc read-bytes "Read n bytes from a file.")
+    (defn read-bytes [f n]
+      (let-do [bytes (Array.allocate n)
+               i 0]
+        (while-do (< i n)
+          (Array.aset-uninitialized! &bytes i (read-byte @(file f)))
+          (++ i))
+        (Result.Success bytes)))
+    (implements read-from-file read-bytes)
   )
 )

--- a/src/byte-reader.carp
+++ b/src/byte-reader.carp
@@ -7,7 +7,7 @@
     (defn read-byte [file]
       (to-byte (Char.from-int (IO.Raw.fgetc file))))
 
-    (doc read-bytes "Read n bytes from a file.")
+    (doc read-bytes "Read `n` bytes from a file.")
     (defn read-bytes [f n]
       (let-do [bytes (Array.allocate n)
                i 0]

--- a/src/byte-reader.carp
+++ b/src/byte-reader.carp
@@ -2,19 +2,22 @@
 
 (defmodule File
   (defmodule ByteReader
-    ;; TODO: Use the safer IO.fgetc once in HEAD
     (doc read-byte "Read a single byte from a file.")
     (defn read-byte [file]
-      (to-byte (Char.from-int (IO.Raw.fgetc file))))
+        (Result.map (IO.fgetc file) &to-byte))
 
     (doc read-bytes "Read `n` bytes from a file.")
     (defn read-bytes [f n]
       (let-do [bytes (Array.allocate n)
-               i 0]
+               i 0
+               result (Result.Success [])]
         (while-do (< i n)
-          (Array.aset-uninitialized! &bytes i (read-byte @(file f)))
+          (match (read-byte @(file f))
+            (Result.Success b) (Array.aset-uninitialized! &bytes i b)
+            (Result.Error err) (do (set! result (Result.Error err)) (break)))
           (++ i))
-        (Result.Success bytes)))
+        (when (not (error? &result)) (set! result (Result.Success bytes)))
+        result))
     (implements read-from-file read-bytes)
 
     (doc read 

--- a/src/reader.carp
+++ b/src/reader.carp
@@ -1,0 +1,7 @@
+;;;; A reader interface.
+;;;; Implementations should return Result.Success containing the read data type
+;;;; value on a successful read.
+;;;; 
+;;;; see: src/byte-reader.carp and src/string-reader.carp for examples. 
+
+(definterface read (Fn [(Ref File) Int] (Result a String)))

--- a/src/reader.carp
+++ b/src/reader.carp
@@ -1,7 +1,15 @@
 ;;;; A reader interface.
+;;;;
 ;;;; Implementations should return Result.Success containing the read data type
 ;;;; value on a successful read.
+;;;;
+;;;; Implementations may assume the input file is confirmed to be readable.
+;;;;
+;;;; This property is enforced in the File API (see File.read) but direct
+;;;; callers of the read-from-file interface will need to perform this check 
+;;;; themselves.
 ;;;; 
 ;;;; see: src/byte-reader.carp and src/string-reader.carp for examples. 
 
-(definterface read (Fn [(Ref File) Int] (Result a String)))
+;; TODO: Add docs for this once supported on interfaces.
+(definterface read-from-file (Fn [(Ref File) Int] (Result a String)))

--- a/src/string-reader.carp
+++ b/src/string-reader.carp
@@ -2,15 +2,13 @@
 
 (defmodule File
   (defmodule StringReader
-    (doc read "reads a string of length `len` from a file."
+    (doc read-string "reads a string of length `len` from a file."
      ("Returns a result containing the string on success and an error if " false)
      "the file is not readable.")
-    (defn read [f len]
-      (if (readable? f)
-        (let-do [s (String.allocate len (Char.from-int 0))]
-          (ignore (IO.Raw.fread &s 1 len @(file f)))
-          (Result.Success s))
-        (Result.Error (fmt "The file “%s” is not readable" (name f)))))
-    (implements read read)
+    (defn read-string [f len]
+      (let-do [s (String.allocate len (Char.from-int 0))]
+        (ignore (IO.Raw.fread &s 1 len @(file f)))
+        (Result.Success s)))
+    (implements read-from-file read-string)
   )
 )

--- a/src/string-reader.carp
+++ b/src/string-reader.carp
@@ -1,0 +1,16 @@
+;;;; String reader
+
+(defmodule File
+  (defmodule StringReader
+    (doc read "reads a string of length `len` from a file."
+     ("Returns a result containing the string on success and an error if " false)
+     "the file is not readable.")
+    (defn read [f len]
+      (if (readable? f)
+        (let-do [s (String.allocate len (Char.from-int 0))]
+          (ignore (IO.Raw.fread &s 1 len @(file f)))
+          (Result.Success s))
+        (Result.Error (fmt "The file “%s” is not readable" (name f)))))
+    (implements read read)
+  )
+)

--- a/src/string-reader.carp
+++ b/src/string-reader.carp
@@ -10,5 +10,13 @@
         (ignore (IO.Raw.fread &s 1 len @(file f)))
         (Result.Success s)))
     (implements read-from-file read-string)
+
+    (doc read 
+      "Reads a string of length n from a file."
+      ("This is a convenient wrapper that fixes the return" false)
+      "type of File.read to String.")
+    (sig read (Fn [&File Int] (Result String String)))
+    (defn read [file n]
+      (File.read file n))
   )
 )


### PR DESCRIPTION
This commit makes read a generic interface and provides two
implementations, byte reader and string reader. The string reader is
just the original read function. The byte reader reads files byte by
byte.

This interface allows users to define read implementations for arbitrary
data types.