### PR TITLE
Add a writer interface

### DIFF
--- a/file.carp
+++ b/file.carp
@@ -1,5 +1,6 @@
 (relative-include "file_helper.h")
 (load "src/reader.carp")
+(load "src/writer.carp")
 
 (defmodule Dir
   (register open (Fn [(Ptr CChar)] (Ptr DIR)) "opendir")
@@ -247,16 +248,16 @@ file.")
   (defn remove [f]
     (ignore (IO.Raw.unlink (name f))))
 
-  (doc write "writes a string `string` to a file.
-
-Returns a result containing nothing on success and an error if the file is not
-writable.")
-  (defn write [f string]
+  (doc write
+    "Writes values of length `n` to a file. "
+    ""
+    ("This function is generic in its input. You can " false)
+    ("provide a custom reader implementation by implementing the " false)
+    "write-to-file interface")
+  (defn write [f len obj]
     (if (writable? f)
-      (let-do [ln (length string)]
-        (ignore (IO.Raw.fwrite string 1 ln @(file f)))
-        (Result.Success 0))
-      (Result.Error (fmt "The file “%s” is not writable" (name f)))))
+        (write-to-file f len obj)
+        (Result.Error (fmt "The file “%s” is not writable" (name f)))))
 
   (doc read 
     "Reads len values from a file."
@@ -297,3 +298,5 @@ not readable.")
 
 (load "src/byte-reader.carp")
 (load "src/string-reader.carp")
+(load "src/byte-writer.carp")
+(load "src/string-writer.carp")

--- a/file.carp
+++ b/file.carp
@@ -249,14 +249,14 @@ file.")
     (ignore (IO.Raw.unlink (name f))))
 
   (doc write
-    "Writes values of length `n` to a file. "
+    "Writes a value to a file. "
     ""
     ("This function is generic in its input. You can " false)
     ("provide a custom reader implementation by implementing the " false)
     "write-to-file interface")
-  (defn write [f len obj]
+  (defn write [f obj]
     (if (writable? f)
-        (write-to-file f len obj)
+        (write-to-file f obj)
         (Result.Error (fmt "The file “%s” is not writable" (name f)))))
 
   (doc read 

--- a/src/byte-writer.carp
+++ b/src/byte-writer.carp
@@ -1,0 +1,25 @@
+(defmodule File
+  (defmodule ByteWriter
+    (defn write-byte [byte file]
+      (let [res (IO.Raw.fputc (to-int (from-byte byte)) file)]
+        (if (= res IO.Raw.EOF)
+            (Result.Error @"failed to write byte to file")
+            (Result.Success res))))
+
+    (defn write-bytes [f n bytes]
+      (let-do [limit (min (Array.length bytes) n)
+               i 0
+               result (Result.Success 0)]
+        (while-do (< i limit)
+          (match (write-byte @(Array.unsafe-nth bytes i) @(file f))
+            (Result.Success _) (set! result (Result.Success i))
+            (Result.Error err) (do (set! result (Result.Error err)) (break)))
+          (++ i))
+        result))
+    (implements write-to-file write-bytes)
+
+    (sig write (Fn [&File Int &(Array Byte)] (Result Int String)))
+    (defn write [file n bytes]
+      (File.write file n bytes))
+  )
+)

--- a/src/byte-writer.carp
+++ b/src/byte-writer.carp
@@ -6,20 +6,19 @@
             (Result.Error @"failed to write byte to file")
             (Result.Success res))))
 
-    (defn write-bytes [f n bytes]
-      (let-do [limit (min (Array.length bytes) n)
-               i 0
+    (defn write-bytes [f bytes]
+      (let-do [i 0
                result (Result.Success 0)]
-        (while-do (< i limit)
+        (while-do (< i (Array.length bytes))
           (match (write-byte @(Array.unsafe-nth bytes i) @(file f))
-            (Result.Success _) (set! result (Result.Success i))
+            (Result.Success _) (set! result (Result.Success (+ i 1)))
             (Result.Error err) (do (set! result (Result.Error err)) (break)))
           (++ i))
         result))
     (implements write-to-file write-bytes)
 
-    (sig write (Fn [&File Int &(Array Byte)] (Result Int String)))
-    (defn write [file n bytes]
-      (File.write file n bytes))
+    (sig write (Fn [&File &(Array Byte)] (Result Int String)))
+    (defn write [file bytes]
+      (File.write file bytes))
   )
 )

--- a/src/string-writer.carp
+++ b/src/string-writer.carp
@@ -1,17 +1,17 @@
 (defmodule File
   (defmodule StringWriter
-    (defn write-string [f n string]
-      (let-do [limit (min n (length string))
-               result (IO.Raw.fwrite string 1 limit @(file f))]
-        (if (< result limit)
+    (defn write-string [f string]
+      (let-do [len (length string)
+               result (IO.Raw.fwrite string 1 len @(file f))]
+        (if (< result len)
             (Result.Error
               (fmt "write error: could not write string to file %s"
                    (name f)))
             (Result.Success result))))
     (implements write-to-file write-string)
 
-    (sig write (Fn [&File Int &String] (Result Int String)))
-    (defn write [f n string]
-      (File.write f n string))
+    (sig write (Fn [&File &String] (Result Int String)))
+    (defn write [f string]
+      (File.write f string))
   )
 )

--- a/src/string-writer.carp
+++ b/src/string-writer.carp
@@ -1,0 +1,17 @@
+(defmodule File
+  (defmodule StringWriter
+    (defn write-string [f n string]
+      (let-do [limit (min n (length string))
+               result (IO.Raw.fwrite string 1 limit @(file f))]
+        (if (< result limit)
+            (Result.Error
+              (fmt "write error: could not write string to file %s"
+                   (name f)))
+            (Result.Success result))))
+    (implements write-to-file write-string)
+
+    (sig write (Fn [&File Int &String] (Result Int String)))
+    (defn write [f n string]
+      (File.write f n string))
+  )
+)

--- a/src/writer.carp
+++ b/src/writer.carp
@@ -1,0 +1,14 @@
+;;;; A writer interface.
+;;;;
+;;;; Implementations should return Result.Success containing the number of
+;;;; values written on a successful write.
+;;;;
+;;;; Implementations may assume the input file is confirmed to be writable
+;;;;
+;;;; This property is enforced in the File API (see File.write) but direct
+;;;; callers of the write-to-file interface will need to perform this check
+;;;; themselves.
+;;;;
+;;;; see: src/byte-writer.carp and src/string-writer.carp for examples.
+
+(definterface write-to-file (Fn [(Ref File) Int (Ref a)] (Result Int String)))

--- a/src/writer.carp
+++ b/src/writer.carp
@@ -11,4 +11,4 @@
 ;;;;
 ;;;; see: src/byte-writer.carp and src/string-writer.carp for examples.
 
-(definterface write-to-file (Fn [(Ref File) Int (Ref a)] (Result Int String)))
+(definterface write-to-file (Fn [(Ref File) a] (Result Int String)))

--- a/test/file.carp
+++ b/test/file.carp
@@ -11,7 +11,7 @@
                   "hi"
                   &(let-do [f (unsafe-from-success (File.open "example"))
                             s @""]
-                    (ignore (File.write &f "hi"))
+                    (ignore (File.write &f 2 "hi"))
                     (set! s (unsafe-from-success (File.read-all &f)))
                     (File.close f)
                     s)

--- a/test/file.carp
+++ b/test/file.carp
@@ -11,7 +11,7 @@
                   "hi"
                   &(let-do [f (unsafe-from-success (File.open "example"))
                             s @""]
-                    (ignore (File.write &f 2 "hi"))
+                    (ignore (File.write &f "hi"))
                     (set! s (unsafe-from-success (File.read-all &f)))
                     (File.close f)
                     s)


### PR DESCRIPTION
This PR is similar to the recent reader interface PR, only this time around we're adding a writer interface, `write-to-file`. Just like the reader, we currently define implementations for Byte Arrays and Strings.

Updates `File.write` and the corresponding test accordingly.